### PR TITLE
Change default loading behavior.  

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,7 @@ arg_enum! {
 
 #[derive(Clone, Debug)]
 pub struct CliArgs {
+    pub config_path_provided: bool,
     pub config_path: String,
     pub subscription: String,
     pub event: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
 
     let matches = get_app_cli(&version).get_matches();
     let mut cli_args = CliArgs {
+        config_path_provided: matches.is_present("config_file"),
         config_path: matches.value_of("config_file").unwrap().to_string(),
         subscription: "".to_string(),
         event: "".to_string(),
@@ -68,7 +69,7 @@ fn main() {
         }
 
         println!("Loading the configuration from {}\n", &cli_args.config_path);
-        let mut config = get_config(&cli_args.config_path);
+        let mut config = get_config(&cli_args.config_path, &cli_args.config_path_provided);
         config.update(&cli_args);
 
         set_azure_environment(&config.subscription()).unwrap();


### PR DESCRIPTION
If `--config-file` is specified, it should only try that (url or local file).  

Otherwise, it should try `demo.yml` in the current directory or use `https://aka.ms/demo-up` to get a configuration.